### PR TITLE
Fix issue when there are no comments

### DIFF
--- a/src/Rule/FailInTryCatchRule.php
+++ b/src/Rule/FailInTryCatchRule.php
@@ -84,6 +84,9 @@ class FailInTryCatchRule implements Rule
     private function hasIgnoreComment(\PhpParser\Node $node, Scope $scope): bool
     {
         $comments = $node->getComments();
+        if (count($comments) === 0) {
+            return false;
+        }
         $lastComment = end($comments);
         $lastCommentText = $lastComment->getText();
 

--- a/tests/Rule/FailInTryCatchRuleTest.php
+++ b/tests/Rule/FailInTryCatchRuleTest.php
@@ -18,6 +18,10 @@ class FailInTryCatchRuleTest extends RuleTestCase
                 'You should always add `$this->fail()` as a last statement in try/catch block.',
                 14,
             ],
+            [
+                'You should always add `$this->fail()` as a last statement in try/catch block.',
+                66,
+            ],
         ]);
     }
 

--- a/tests/Rule/data/assert-fail-in-try-catch.php
+++ b/tests/Rule/data/assert-fail-in-try-catch.php
@@ -60,6 +60,18 @@ class DummyTest extends TestCase
         }
 
 
+        // exception should be thrown, as quantity has empty value '' and snflk will complain.
+        try {
+            $workspaces->loadWorkspaceData($workspace['id'], $options);
+            if ($workspaceBackend === self::BACKEND_REDSHIFT && $sourceBackend === self::BACKEND_SNOWFLAKE) {
+                // this will not throw
+                $this->expectNotToPerformAssertions();
+            } else {
+                $this->fail('Should have thrown');
+            }
+        } catch (ClientException $e) {
+            $this->assertEquals('workspace.tableLoad', $e->getStringCode());
+        }
     }
 
     private function doSomething()


### PR DESCRIPTION
When there are no comments and the fail is missing, the plugin would fail. 