### PR TITLE
Allow ignoring error for 1.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM php:8.1
+
+ARG COMPOSER_FLAGS="--prefer-dist --no-interaction"
+ARG DEBIAN_FRONTEND=noninteractive
+ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV COMPOSER_PROCESS_TIMEOUT 3600
+
+WORKDIR /code/
+
+COPY docker/php-prod.ini /usr/local/etc/php/php.ini
+COPY docker/composer-install.sh /tmp/composer-install.sh
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git \
+        locales \
+        unzip \
+	&& rm -r /var/lib/apt/lists/* \
+	&& sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen \
+	&& locale-gen \
+	&& chmod +x /tmp/composer-install.sh \
+	&& /tmp/composer-install.sh
+
+ENV LANGUAGE=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+
+## Composer - deps always cached unless changed
+# First copy only composer files
+COPY composer.* /code/
+
+# Download dependencies, but don't run scripts or init autoloaders as the app is missing
+RUN composer install $COMPOSER_FLAGS --no-scripts --no-autoloader
+
+# Copy rest of the app
+COPY . /code/
+
+# Run normal composer - all deps are cached already
+RUN composer install $COMPOSER_FLAGS
+
+CMD ["tail", "-f", "/dev/null"]

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "phpstan-plugin",
     "description": "Collection of phpstan rules for phpunit",
     "require": {
-        "phpstan/phpstan": "^1.10"
+        "phpstan/phpstan": "^1.11"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.4"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  dev:
+    build: .
+    volumes:
+      - ./:/code
+      - ./data:/data
+
+  dev-xdebug:
+    build:
+      context: docker/xdebug
+      args:
+        IMAGE: phpstan-phpunit-dev
+    volumes:
+      - ./:/code
+      - ./data:/data

--- a/docker/composer-install.sh
+++ b/docker/composer-install.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+EXPECTED_SIGNATURE=$(curl -s https://composer.github.io/installer.sig)
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');")
+
+if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+then
+    >&2 echo 'ERROR: Invalid installer signature'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet --install-dir=/usr/local/bin/ --filename=composer
+RESULT=$?
+rm composer-setup.php
+exit $RESULT

--- a/docker/php-prod.ini
+++ b/docker/php-prod.ini
@@ -1,0 +1,19 @@
+; Recommended production values
+display_errors = Off
+display_startup_errors = Off
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
+html_errors = On
+log_errors = On
+max_input_time = 60
+output_buffering = 4096
+register_argc_argv = Off
+request_order = "GP"
+session.gc_divisor = 1000
+session.sid_bits_per_character = 5
+short_open_tag = Off
+track_errors = Off
+variables_order = "GPCS"
+
+; Custom
+date.timezone = UTC
+memory_limit = -1

--- a/docker/xdebug/.gitignore
+++ b/docker/xdebug/.gitignore
@@ -1,0 +1,2 @@
+xdebug.ini
+xdebug.log

--- a/docker/xdebug/Dockerfile
+++ b/docker/xdebug/Dockerfile
@@ -1,0 +1,6 @@
+ARG IMAGE
+
+FROM ${IMAGE}
+
+RUN pecl install xdebug \
+  && docker-php-ext-enable xdebug

--- a/docker/xdebug/xdebug.ini.dist
+++ b/docker/xdebug/xdebug.ini.dist
@@ -1,0 +1,10 @@
+# @see https://3.xdebug.org/docs/all_settings
+xdebug.mode=debug
+xdebug.client_host =host.docker.internal
+xdebug.client_port=9003
+xdebug.discover_client_host=1
+xdebug.start_with_request=default
+xdebug.idekey=PHPSTORM
+xdebug.cli_color=1
+xdebug.max_nesting_level=1000
+xdebug.output_dir=/tmp/debug

--- a/src/Rule/FailInTryCatchRule.php
+++ b/src/Rule/FailInTryCatchRule.php
@@ -83,7 +83,7 @@ class FailInTryCatchRule implements Rule
         $lastComment = end($comments);
         $lastCommentText = $lastComment->getText();
 
-        return preg_match('|@phpstan-ignore: *tomasfejfar-phpstan-phpunit.missingFailInTryCatch|', $lastCommentText)
+        return preg_match('|@phpstan-ignore *tomasfejfar.phpstanPhpunit.missingFailInTryCatch|', $lastCommentText)
             === 1;
     }
 
@@ -98,7 +98,7 @@ class FailInTryCatchRule implements Rule
                 'You should always add `$this->fail()` as a last statement in try/catch block.'
             )
                 ->line($lastTryStmt->getLine())
-                ->identifier('tomasfejfar-phpstan-phpunit.missingFailInTryCatch')
+                ->identifier('tomasfejfar.phpstanPhpunit.missingFailInTryCatch')
                 ->build();
         }
         return $errors;

--- a/src/Rule/FailInTryCatchRule.php
+++ b/src/Rule/FailInTryCatchRule.php
@@ -74,26 +74,10 @@ class FailInTryCatchRule implements Rule
         return true;
     }
 
-    private function hasIgnoreComment(\PhpParser\Node $node, Scope $scope): bool
-    {
-        $comments = $node->getComments();
-        if (count($comments) === 0) {
-            return false;
-        }
-        $lastComment = end($comments);
-        $lastCommentText = $lastComment->getText();
-
-        return preg_match('|@phpstan-ignore *tomasfejfar.phpstanPhpunit.missingFailInTryCatch|', $lastCommentText)
-            === 1;
-    }
-
     public function isFailOrIgnore($lastTryStmt, Scope $scope): array
     {
         $errors = [];
-        if (
-            !$this->isFailMethodCall($lastTryStmt, $scope)
-            && !$this->hasIgnoreComment($lastTryStmt, $scope)
-        ) {
+        if (!$this->isFailMethodCall($lastTryStmt, $scope)) {
             $errors[] = RuleErrorBuilder::message(
                 'You should always add `$this->fail()` as a last statement in try/catch block.'
             )

--- a/tests/Rule/data/assert-fail-in-try-catch.php
+++ b/tests/Rule/data/assert-fail-in-try-catch.php
@@ -33,27 +33,27 @@ class DummyTest extends TestCase
         }
 
         try {
-            // @phpstan-ignore: tomasfejfar-phpstan-phpunit.missingFailInTryCatch
+            // @phpstan-ignore tomasfejfar.phpstanPhpunit.missingFailInTryCatch
             $this->doSomething();
         } catch (\Exception $e) {
             $this->assertEquals('foo', $e->getMessage());
         }
 
         try {
-            //     @phpstan-ignore: tomasfejfar-phpstan-phpunit.missingFailInTryCatch
+            //     @phpstan-ignore tomasfejfar.phpstanPhpunit.missingFailInTryCatch
             $this->doSomething();
         } catch (\Exception $e) {
             $this->assertEquals('foo', $e->getMessage());
         }
 
         try {
-            //@phpstan-ignore: tomasfejfar-phpstan-phpunit.missingFailInTryCatch
+            //@phpstan-ignore tomasfejfar.phpstanPhpunit.missingFailInTryCatch
             $this->doSomething();
         } catch (\Exception $e) {
             $this->assertEquals('foo', $e->getMessage());
         }
         try {
-            // @phpstan-ignore: tomasfejfar-phpstan-phpunit.missingFailInTryCatch because of some reason
+            // @phpstan-ignore tomasfejfar.phpstanPhpunit.missingFailInTryCatch (because of some reason)
             $this->doSomething();
         } catch (\Exception $e) {
             $this->assertEquals('foo', $e->getMessage());


### PR DESCRIPTION
The error ignoring comment changed (removed colon + casing of error changed):
```diff
-     // @phpstan-ignore: tomasfejfar-phpstan-phpunit.missingFailInTryCatch
+     // @phpstan-ignore tomasfejfar.phpstanPhpunit.missingFailInTryCatch
```